### PR TITLE
:art: Add --version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ make develop
 make unit
 ```
 
+## Development
+
+### Editable Mode
+
+Install the CLI in editable mode with development dependencies
+
+```bash
+# Clone the repository
+git clone https://github.com/outscale/osc-bsu-backup.git
+cd osc-bsu-backup
+
+# Create and activate a virtual environment
+python -m venv venv
+source venv/bin/activate
+
+# CLI in editable mode
+pip install -e ".[dev]"
+or 
+python3 setup.py develop
+```
+
+Changes in the `osc_bsu_backup/` directory will be immediately reflected without reinstalling.
+
 ```bash
 #you must have an account on the region eu-west-2 from Outscale
 #~/.aws/credentials

--- a/osc_bsu_backup/cli.py
+++ b/osc_bsu_backup/cli.py
@@ -25,6 +25,7 @@ class Args:
     profile: Optional[str]
     client_cert: Optional[str]
     debug: bool
+    version: bool
 
 
 def backup(args: Args) -> None:
@@ -53,7 +54,6 @@ def backup(args: Args) -> None:
 
 
 def main() -> None:
-    logger.info("osc_bsu_backup: %s", __version__)
 
     parser = argparse.ArgumentParser(description=f"osc-bsu-backup: {__version__}")
     parser.add_argument(
@@ -135,8 +135,20 @@ def main() -> None:
     parser.add_argument(
         "--debug", dest="debug", action="store_true", default=False, help="enable debug"
     )
+    parser.add_argument(
+        "--version",
+        dest="version",
+        action="store_true",
+        default=False,
+        help="Show script version and exit"
+    )
     args = Args(**vars(parser.parse_args()))
 
+    if args.version:
+        print(f"osc-bsu-backup version {__version__}")
+        exit(0)
+
+    logger.info("osc_bsu_backup: %s", __version__)
     if args.instances_tags:
         for tag in args.instances_tags:
             if len(tag.split(":")) != 2:

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         'console_scripts': ['osc-bsu-backup = osc_bsu_backup.cli:main']
     },
     install_requires=[
-        'boto3'
+        'boto3',
+        'mypy_boto3_ec2'
     ]
 )


### PR DESCRIPTION
This changes adds:
- an option to display version of the tool directly
- It also adds a missing dependency package (mypy_boto3_ec2 https://github.com/outscale/osc-bsu-backup/issues/13)
- It updates README.md for developers.